### PR TITLE
Fixed link to story download

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ As GitHub restricts each file to be only 100MB and also has policies against dat
 ![](FileDropperDownloadScreen.png?raw=true)
 
 ####Stories Download URL####
-http://www.filedropper.com/hncommentsall
+http://www.filedropper.com/hnstoriesall
 
 ####Comments Download URL####
 http://www.filedropper.com/hncommentsall


### PR DESCRIPTION
Both links in the download section pointed to hncommentsall. I guessed the name of the story archive and found a file, I hope it is the right one.
